### PR TITLE
Cypher service csv output

### DIFF
--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -12,7 +12,7 @@ class Service::CypherController < ServicesController
     return unless authorize_user_from_token!
     cypher = params[:query]
     format = params[:format]
-    format = "json" unless format != nil
+    format = "cypher" unless format != nil
 
     if cypher == nil
       render_bad_request(title: "Missing a 'query' parameter.")
@@ -24,7 +24,7 @@ class Service::CypherController < ServicesController
       render_unauthorized(title: "You are not authorized to use this Cypher command.")
     elsif cypher =~ /\b(limit)\b/i
       case format
-      when "json" then
+      when "cypher" then
         render json: TraitBank.query(cypher)
       when "csv" then
         self.content_type = 'text/csv'

--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -1,5 +1,7 @@
 # Cypher query via web services API
 
+require 'csv'
+
 class Service::CypherController < ServicesController
   before_action :require_power_user, only: :form
 
@@ -9,16 +11,37 @@ class Service::CypherController < ServicesController
   def query
     return unless authorize_user_from_token!
     cypher = params[:query]
+    format = params[:format]
+    format = "json" unless format != nil
+
+    if cypher == nil
+      render_bad_request(title: "Missing a 'query' parameter.")
 
     # Web users are not supposed to modify the database.  The following
     # is an ad hoc filter to try to prevent this, at least when it is 
     # accidental; one shouldn't expect it to be secure against a concerted attack.
-    if cypher =~ /\b(delete|create|set|remove|merge|call|drop|load)\b/i
-      render_unauthorized errors: {forbidden: ["You are not authorized to use this command."]}
+    elsif cypher =~ /\b(delete|create|set|remove|merge|call|drop|load)\b/i
+      render_unauthorized(title: "You are not authorized to use this Cypher command.")
     elsif cypher =~ /\b(limit)\b/i
-      render json: TraitBank.query(cypher)
+      case format
+      when "json" then
+        render json: TraitBank.query(cypher)
+      when "csv" then
+        self.content_type = 'text/csv'
+        results = TraitBank.query(cypher)
+        # Streaming output
+        self.response_body =
+          Enumerator.new do |y|
+            y << CSV.generate_line(results["columns"])
+            results["data"].each do |row|
+              y << CSV.generate_line(row)
+            end
+          end    # end Enumerator
+      else
+        render_bad_request(title: "Unrecognized 'format' parameter value.", format: format)
+      end        # end case
     else
-      render_unauthorized errors: {forbidden: ["You must specify a LIMIT for this operation."]}
+      render_unauthorized(title: "You must specify a LIMIT for this operation.")
     end
   end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -6,6 +6,10 @@ class ServicesController < ApplicationController
   # We might want HTML responses as well, and/or csv
   respond_to :json
 
+  # **** Maybe get rid of the authorization check here, and instead
+  # **** make sure that it gets done in the authorize_user_from_token!
+  # **** method?  No, better to fail fast.
+
   def authenticate_service
     # User needs to be logged in already!
     # Future: provide an automated service so scripts can fetch a token.
@@ -15,10 +19,10 @@ class ServicesController < ApplicationController
       if current_user.is_power_user?
         render json: {token: jwt_token(current_user)}
       else
-        render_unauthorized errors: {forbidden: ["You are not authorized to use the web services."]}
+        render_unauthorized title: "You are not authorized to use the web services."
       end
     else
-      render_unauthenticated errors: {unauthenticated: ["Please log in, then try again."]}
+      render_unauthenticated title: "Please log in, then try again."
     end
   end
 
@@ -31,19 +35,19 @@ class ServicesController < ApplicationController
 
   def authorize_user_from_token!
     if current_user
-      return render_unauthorized errors: {forbidden: ["You are not authorized to use the web services."]} \
+      return render_unauthorized title: "You are not authorized to use the web services." \
          unless current_user.is_power_user?    # Unauthorized
       @current_user = current_user
     else
       the_claims = claims
-      return render_unauthenticated errors: {unauthenticated: ["Missing or invalid token."]} \
+      return render_unauthenticated title: "Missing or invalid token." \
         unless the_claims    # Unauthenticated
       user = User.find_by_email(the_claims[0]['user'])
-      return render_unauthenticated errors: {unauthenticated: ["Invalid token."]} \
+      return render_unauthenticated title: "Invalid token." \
         unless user          # ill-formed token
       if user &&
          the_claims[0]['encrypted_password'] == user.encrypted_password
-        return render_unauthorized errors: {forbidden: ["Invalid token."]} \
+        return render_unauthorized title: "Invalid token." \
           unless user.is_power_user?    # Unauthorized
         @current_user = user
       end
@@ -85,13 +89,21 @@ class ServicesController < ApplicationController
   # put forth a 'standard' way for services to report problems, but I
   # haven't found it yet.  Later.
 
+  # e.g. perhaps http://jsonapi.org/format/#error-objects
+  # which prescribes :title as the main way of giving the error message.
+
   def render_unauthenticated(payload)
-    render json: payload.merge(response: { status: 401 }), :status => 401
+    render json: payload.merge(:status => "401 Unauthenticated"), status: 401
     nil
   end
 
   def render_unauthorized(payload)
-    render json: payload.merge(response: { status: 403 }), :status => 403
+    render json: payload.merge(:status => "403 Unauthorized"), status: 403
+    nil
+  end
+
+  def render_bad_request(payload)
+    render json: payload.merge(:status => "400 Bad Request"), status: 400
     nil
   end
 

--- a/doc/cypher.py
+++ b/doc/cypher.py
@@ -19,7 +19,7 @@ def doit(tokenfile, server, query, queryfile, format):
     with open(tokenfile, 'r') as infile:
         api_token = infile.read().strip()
     url = "%s/service/cypher" % server.rstrip('/')
-    if format == None: format = "json"
+    if format == None: format = "cypher"
     data = {"query": query, "format": format}
     r = requests.get(url,
                      stream=(format=="csv"),

--- a/doc/cypher.py
+++ b/doc/cypher.py
@@ -1,33 +1,55 @@
 #!/usr/bin/python
 
+# This is an example API client program.  It invokes the `cypher`
+# service with parameters supplied on the command line.  Actual use of
+# the API could be as simple as the central HTTP request, which can be
+# done with wget or curl, or as complex as a translation to your
+# favorite programming language, as a module to be used in a larger
+# program.
+
 import requests, argparse, json, sys
 
 default_server = "https://beta.eol.org"
 sample_data = {"a": "has space", "b": "has %", "c": "has &"}
 
-def doit(tokenfile, server, query, queryfile):
+def doit(tokenfile, server, query, queryfile, format):
     if queryfile != None:
         with open(queryfile, 'r') as infile:
             query = infile.read().strip()
     with open(tokenfile, 'r') as infile:
         api_token = infile.read().strip()
     url = "%s/service/cypher" % server.rstrip('/')
-    data = {"query": query}
+    if format == None: format = "json"
+    data = {"query": query, "format": format}
     r = requests.get(url,
+                     stream=(format=="csv"),
                      headers={"accept": "application/json",
                               "authorization": "JWT " + api_token},
                      params=data)
     if r.status_code != 200:
         sys.stderr.write('HTTP status %s\n' % r.status_code)
-    j = {}
-    try:
-        j = r.json()
-    except ValueError:
-        sys.stderr.write('JSON syntax error\n')
+    ct = r.headers.get("Content-Type").split(';')[0]
+    if ct == "application/json":
+        j = {}
+        try:
+            j = r.json()
+        except ValueError:
+            sys.stderr.write('JSON syntax error\n')
+            print >>sys.stderr, r.text[0:1000]
+            sys.exit(1)
+        json.dump(j, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write('\n')
+    elif ct == "text/csv":
+        # https://stackoverflow.com/questions/16694907/how-to-download-large-file-in-python-with-requests-py#16696317
+        for chunk in r.iter_content(chunk_size=1024): 
+            if chunk: # filter out keep-alive new chunks
+                sys.stdout.write(chunk)
+    elif ct == "text/plain":
+        print >>sys.stderr, r.text
+    else:
+        sys.stderr.write('Unrecognized response content-type: %s\n' % ct)
         print >>sys.stderr, r.text[0:1000]
         sys.exit(1)
-    json.dump(j, sys.stdout, indent=2, sort_keys=True)
-    sys.stdout.write('\n')
     if r.status_code != 200:
         sys.exit(1)
 
@@ -37,5 +59,6 @@ if __name__ == '__main__':
     parser.add_argument('--query', help='cypher query to run', default=None)
     parser.add_argument('--queryfile', help='file containing cypher query to run', default=None)
     parser.add_argument('--server', help='URL for EOL web app server', default=default_server)
+    parser.add_argument('--format', help='result format (json or csv)', default=None)
     args=parser.parse_args()
-    doit(args.tokenfile, args.server, args.query, args.queryfile)
+    doit(args.tokenfile, args.server, args.query, args.queryfile, args.format)


### PR DESCRIPTION
New parameter `format` to API service `services/cypher` with values `cypher` or `csv`, default `cypher`

I piggybacked some query documentation changes, sorry