### PR TITLE
Bulk traits dumper rake

### DIFF
--- a/app/support/trait_bank/traits_dumper.rb
+++ b/app/support/trait_bank/traits_dumper.rb
@@ -6,13 +6,13 @@ require 'fileutils'
 
 class TraitBank::TraitsDumper
   def self.dump_clade(clade_page_id, dest, csvdir, limit)
-    new(Integer(clade_page_id), dest, csvdir, limit).doit
+    new(clade_page_id, dest, csvdir, limit).doit
   end
   def initialize(clade_page_id, dest, csvdir, limit)
-    @clade = clade_page_id
+    @clade = Integer(clade_page_id)
     @dest = dest
     @csvdir = csvdir
-    @limit = limit
+    @limit = Integer(limit)
   end
   def doit
     write_zip [spew_pages,

--- a/app/support/trait_bank/traits_dumper.rb
+++ b/app/support/trait_bank/traits_dumper.rb
@@ -1,0 +1,149 @@
+# Generate CSV files expressing trait information for a single taxon
+# recursively.
+
+require 'csv'
+require 'fileutils'
+
+class TraitBank::TraitsDumper
+  def self.dump_clade(clade_page_id, destdir, limit)
+    new(clade_page_id, destdir, limit).doit
+  end
+  def initialize(clade_page_id, destdir, limit)
+    @clade = clade_page_id
+    @destdir = destdir
+    @limit = limit
+  end
+  def doit
+    write_zip [spew_pages,
+               spew_traits,
+               spew_metadatas,
+               spew_terms]
+    # TBD: Zip them all up into a .zip file!
+  end
+
+  def write_zip(paths)
+    "done"
+  end
+
+  #---- Query #3: Pages
+
+  def spew_pages
+
+    pages_query =
+     "MATCH (page:Page)-[:parent*]->(clade:Page {page_id: #{@clade}})
+      WHERE page.canonical IS NOT NULL
+      OPTIONAL MATCH (page)-[:parent]->(parent:Page)
+      RETURN page.page_id, parent.page_id, page.canonical 
+      LIMIT #{@limit}"
+
+    pages_keys = ["page_id", "parent_id", "canonical"] #fragile
+
+    pages_result = TraitBank.query(pages_query)
+    spew_csv(pages_result, pages_keys, "pages.csv")
+
+  end
+
+  #---- Query #2: Traits
+
+  def spew_traits
+
+    traits_query =
+     "MATCH (t:Trait)<-[:trait]-(page:Page),
+            (page)-[:parent*]->(clade:Page {page_id: #{@clade}})
+      WHERE page.canonical IS NOT NULL
+      OPTIONAL MATCH (t)-[:supplier]->(r:Resource)
+      OPTIONAL MATCH (t)-[:predicate]->(predicate:Term)
+      OPTIONAL MATCH (t)-[:object_term]->(obj:Term)
+      OPTIONAL MATCH (t)-[:normal_units_term]->(normal_units:Term)
+      OPTIONAL MATCH (t)-[:units_term]->(units:Term)
+      RETURN t.eol_pk, page.page_id, r.resource_pk, r.resource_id,
+             t.source, t.scientific_name, predicate.uri,
+             t.object_page_id, obj.uri,
+             t.normal_measurement, normal_units.uri, t.normal_units, 
+             t.measurement, units.uri, t.units, 
+             t.literal
+      LIMIT #{@limit}"
+
+    # Matching the keys used in the tarball if possible (even when inconsistent)
+    # E.g. should "predicate" be "predicate_uri" ?
+
+    traits_keys = ["eol_pk", "page_id", "resource_pk", "resource_id",
+                   "source", "scientific_name", "predicate",
+                   "object_page_id", "value_uri",
+                   "normal_measurement", "normal_units_uri", "normal_units",
+                   "measurement", "units_uri", "units",
+                   "literal"]
+
+    traits_result = TraitBank.query(traits_query)
+
+    spew_csv(traits_result, traits_keys, "traits.csv")
+
+  end
+
+  #---- Query #1: Metadatas
+
+  def spew_metadatas
+
+    metadata_query = 
+     "MATCH (m:MetaData)<-[:metadata]-(t:Trait),
+            (t)<-[:trait]-(page:Page),
+            (page)-[:parent*]->(clade:Page {page_id: #{@clade}})
+      WHERE page.canonical IS NOT NULL
+      OPTIONAL MATCH (m)-[:predicate]->(predicate:Term)
+      OPTIONAL MATCH (m)-[:object_term]->(obj:Term)
+      OPTIONAL MATCH (m)-[:units_term]->(units:Term)
+      RETURN m.eol_pk, t.eol_pk, predicate.uri, obj.uri, m.measurement, units.uri, m.literal
+      LIMIT #{@limit}"
+
+    metadata_keys = ["eol_pk", "trait_eol_pk", "predicate", "value_uri",
+                     "measurement", "units_uri", "literal"]
+    metadata_result = TraitBank.query(metadata_query)
+
+    spew_csv(metadata_result, metadata_keys, "metadata.csv")
+
+  end
+
+  #---- Query #0: Terms
+
+  def spew_terms
+
+    # I'm not sure where there exist multiple Term nodes for a single URI?
+
+    terms_query =
+     "MATCH (r:Term)
+      RETURN r.uri, r.name, r.type
+      ORDER BY r.uri
+      LIMIT #{@limit}"
+
+    terms_keys = ["uri", "name", "type"]
+    terms_result = TraitBank.query(terms_query)
+
+    spew_csv(terms_result, terms_keys, "terms.csv")
+
+  end
+
+  # Utility
+  def spew_csv(start, keys, fname)
+    STDERR.puts "#{fname} #{start["data"].length}"
+    FileUtils.mkdir_p @destdir
+    path = "#{@destdir}/#{fname}"
+    csv = CSV.open(path, "wb")
+    csv << keys
+    start["data"].each do |row|
+      csv << row
+    end
+    csv.close
+    path
+  end
+
+end
+
+# TESTING
+# sample_clade = 7662  # carnivora
+# TraitBank::TraitsDumper.dump_clade(sample_clade,
+#                                  "sample-dumps/#{sample_clade}-short-csv",
+#                                  10)
+
+# REAL THING
+# TraitBank::TraitsDumper.dump_clade(sample_clade,
+#   "sample-dumps/#{sample_clade}-csv", 200000)

--- a/doc/cypher.py
+++ b/doc/cypher.py
@@ -5,7 +5,10 @@ import requests, argparse, json, sys
 default_server = "https://beta.eol.org"
 sample_data = {"a": "has space", "b": "has %", "c": "has &"}
 
-def doit(tokenfile, server, query):
+def doit(tokenfile, server, query, queryfile):
+    if queryfile != None:
+        with open(queryfile, 'r') as infile:
+            query = infile.read().strip()
     with open(tokenfile, 'r') as infile:
         api_token = infile.read().strip()
     url = "%s/service/cypher" % server.rstrip('/')
@@ -16,13 +19,23 @@ def doit(tokenfile, server, query):
                      params=data)
     if r.status_code != 200:
         sys.stderr.write('HTTP status %s\n' % r.status_code)
-    json.dump(r.json(), sys.stdout, indent=2, sort_keys=True)
+    j = {}
+    try:
+        j = r.json()
+    except ValueError:
+        sys.stderr.write('JSON syntax error\n')
+        print >>sys.stderr, r.text[0:1000]
+        sys.exit(1)
+    json.dump(j, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write('\n')
+    if r.status_code != 200:
+        sys.exit(1)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--tokenfile', help='file containing bare API token', default=None)
     parser.add_argument('--query', help='cypher query to run', default=None)
+    parser.add_argument('--queryfile', help='file containing cypher query to run', default=None)
     parser.add_argument('--server', help='URL for EOL web app server', default=default_server)
     args=parser.parse_args()
-    doit(args.tokenfile, args.server, args.query)
+    doit(args.tokenfile, args.server, args.query, args.queryfile)

--- a/doc/trait-bank-dumps.md
+++ b/doc/trait-bank-dumps.md
@@ -36,7 +36,7 @@ Command parameters are passed via environment variables:
         be dumped.  Default is all life (2913056).
  - `LIMIT`: size limit for the query result sets.  You can make this a small
             number, if you're just debugging the infrastructure or queries.
-            Default is big (1000000).
+            Default is big (100 million as of this writing).
  - `CSVDIR`:  pathname of the directory to which the intermediate CSV 
             files will be written.  Default is a directory created
         under `/tmp` with a name starting with `traitbank_`.

--- a/doc/trait-bank-dumps.md
+++ b/doc/trait-bank-dumps.md
@@ -1,8 +1,9 @@
 # Dumping Traitbank
 
 The `dump_traits` family of `rake` commands is intended to create
-Traitbank dumps, which anyone can download either from the main web
-site or from the opendata site.
+Traitbank dumps, which anyone can download, from the main web site or
+from the opendata site (depending on how we eventually decide to
+deploy them).
 
 At present (October 2018) the scripts are driven entirely from the
 neo4j graphdb.  This is based on the hypothesis that when people say
@@ -12,18 +13,17 @@ tables (e.g. synonyms or vernaculars from the MySQL database), they
 will be able to get them in some other way.  I don't know if this is
 true; there may be more work to do here.
 
-## `dump_traits:dump`
+### `dump_traits:dump`
 
-Purpose of this command: At the command line, generate a ZIP file
-dump of the entire trait graphdb.  See the associated support module
-[traits_dumper.rb](../app/support/trait_bank/traits_dumper.rb).
+Purpose of this command: At the command line, generate a ZIP file dump
+of the entire trait graphdb.  See the associated support module
+[traits_dumper.rb](../app/support/trait_bank/traits_dumper.rb) to see
+how it's implemented.
 
 The ZIP file will contain four `.csv` files, one for each major kind
 of node: pages, traits, metadata, and terms.
 
 The command can also be used for partial dumps of particular clades.
-To obtain csv files via the web service, use the format=csv option
-for the appropriate web service.
 
 Command parameters are passed via environment variables:
 
@@ -44,7 +44,28 @@ Command parameters are passed via environment variables:
         care of this eventually, and in the meantime they are there
         for examination.
 
-## `dump_traits:smoke`
+### `dump_traits:smoke`
 
-This is for testing only.  Same as `dump` but sets `ID` to 7662
-(Carnivora) and `LIMIT` to 100 and takes a few other shortcuts.
+This is for testing only.  Same as `dump` but defaults `ID` to 7662
+(Carnivora), defaults `LIMIT` to 100, and defaults `ZIP` to a file in
+the current directory.
+
+## Testing this module
+
+Tests to do in sequence (easier to harder):
+
+  1. Smoke test: 
+         bundle exec rake dump_traits:smoke
+     - should write a file in the current directory whose name starts with 'traitbank_' and ends with _smoke.zip
+     - size of file should be >= 7000 bytes and < 70000 bytes
+     - you can delete the .zip file
+  2. Carnivora:
+         time bundle exec rake ID=7662 ZIP=test1.zip dump_traits:dump
+     - size of test1.zip should be >= 400000
+     - you can delete test1.zip
+  3. Vertebrates:
+         time bundle exec rake ID=2774383 ZIP=test2.zip dump_traits:dump
+     - also tell me the size of the file
+     - you can delete test1.zip
+  4. All life:
+         time bundle exec rake ZIP=test3.zip dump_traits:dump

--- a/doc/trait-bank-dumps.md
+++ b/doc/trait-bank-dumps.md
@@ -54,18 +54,18 @@ the current directory.
 
 Tests to do in sequence (easier to harder):
 
-  1. Smoke test: 
-         bundle exec rake dump_traits:smoke
+  1. Smoke test: \
+         `bundle exec rake dump_traits:smoke`
      - should write a file in the current directory whose name starts with 'traitbank_' and ends with _smoke.zip
      - size of file should be >= 7000 bytes and < 70000 bytes
      - you can delete the .zip file
-  2. Carnivora:
-         time bundle exec rake ID=7662 ZIP=test1.zip dump_traits:dump
+  2. Carnivora:\
+         `time bundle exec rake ID=7662 ZIP=test1.zip dump_traits:dump`
      - size of test1.zip should be >= 400000
      - you can delete test1.zip
-  3. Vertebrates:
-         time bundle exec rake ID=2774383 ZIP=test2.zip dump_traits:dump
+  3. Vertebrates:\
+         `time bundle exec rake ID=2774383 ZIP=test2.zip dump_traits:dump`
      - also tell me the size of the file
      - you can delete test1.zip
-  4. All life:
-         time bundle exec rake ZIP=test3.zip dump_traits:dump
+  4. All life:\
+         `time bundle exec rake ZIP=test3.zip dump_traits:dump`

--- a/doc/trait_bank_dumps.md
+++ b/doc/trait_bank_dumps.md
@@ -1,0 +1,50 @@
+# Dumping Traitbank
+
+The `dump_traits` family of `rake` commands is intended to create
+Traitbank dumps, which anyone can download either from the main web
+site or from the opendata site.
+
+At present (October 2018) the scripts are driven entirely from the
+neo4j graphdb.  This is based on the hypothesis that when people say
+they want "all the traits", then all the information they need will be
+present in the graphdb, not the MySQL database.  If they need other
+tables (e.g. synonyms or vernaculars from the MySQL database), they
+will be able to get them in some other way.  I don't know if this is
+true; there may be more work to do here.
+
+## `dump_traits:dump`
+
+Purpose of this command: At the command line, generate a ZIP file
+dump of the entire trait graphdb.  See the associated support module
+[traits_dumper.rb](../app/support/trait_bank/traits_dumper.rb).
+
+The ZIP file will contain four `.csv` files, one for each major kind
+of node: pages, traits, metadata, and terms.
+
+The command can also be used for partial dumps of particular clades.
+To obtain csv files via the web service, use the format=csv option
+for the appropriate web service.
+
+Command parameters are passed via environment variables:
+
+ - `ZIP`: pathname of the .zip file to be written (should include
+         the terminal '.zip').  The default value comes from the `path` method
+         of the `DataDownload` class, which I think
+         corresponds to the URL with path `/data/downloads/`, and the filename 
+         has a form similar to `traitbank_YYYYMMDD.zip`.
+ - `ID`: the page id of the taxon that is the root of the subtree to
+        be dumped.  Default is all life (2913056).
+ - `LIMIT`: size limit for the query result sets.  You can make this a small
+            number, if you're just debugging the infrastructure or queries.
+            Default is big (1000000).
+ - `CSVDIR`:  pathname of the directory to which the intermediate CSV 
+            files will be written.  Default is a directory created
+        under `/tmp` with a name starting with `traitbank_`.
+        The files are not deleted at the end; the operating system will take
+        care of this eventually, and in the meantime they are there
+        for examination.
+
+## `dump_traits:smoke`
+
+This is for testing only.  Same as `dump` but sets `ID` to 7662
+(Carnivora) and `LIMIT` to 100 and takes a few other shortcuts.

--- a/lib/tasks/dump_traits.rake
+++ b/lib/tasks/dump_traits.rake
@@ -1,27 +1,32 @@
-# Purpose of this command: At the command line, generate a CSV file
-# dump of the entire trait graphdb.  See the associated support module.
-# This can also be used for partial dumps of particular clades.
-# To obtain csv files via the web service, use the format=csv option
-# for the appropriate web service.
+# See ../../doc/dump_traits.md
 
 namespace :dump_traits do
 
   desc 'Dump traits information from neo4j graphdb into a set of .csv files.'
   task dump: :environment do
-    clade = ENV['ID'] ? ENV['ID'] : 2913056     # default = life
-    limit = ENV['LIMIT'] ? ENV['LIMIT'] : 1000000
-    TraitBank::TraitsDumper.dump_clade(clade,
-                                       "sample-dumps/#{clade}-csv",
-                                       limit)
+    clade = ENV['ID'] || '2913056'     # default = life
+    limit = ENV['LIMIT'] || 1000000
+    prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}"
+    prefix = "#{prefix}_#{clade}" if ENV['ID']
+    prefix = "#{prefix}_limit_#{limit}" if ENV['LIMIT']
+    csvdir = ENV['CSVDIR'] || "/tmp/#{prefix}_csv_temp"
+    # This is not very rubyesque
+    if ENV['ZIP']
+      dest = ENV['ZIP']
+    else
+      dest = TraitBank::DataDownload.path.join("#{prefix}.zip")
+    end
+    TraitBank::TraitsDumper.dump_clade(clade, dest, csvdir, limit)
   end
 
   desc 'Smoke test of traits dumper; finishes quickly.'
   task smoke: :environment do
-    clade = ENV['ID'] ? ENV['ID'] : 7662     # Carnivora
-    limit = ENV['LIMIT'] ? ENV['LIMIT'] : 100
-    TraitBank::TraitsDumper.dump_clade(clade,
-                                       "sample-dumps/#{clade}-smoke-csv",
-                                       limit)
+    clade = ENV['ID'] || 7662     # Carnivora
+    limit = ENV['LIMIT'] || 100
+    prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}_#{clade}_#{limit}"
+    csvdir = ENV['CSVDIR'] || "/tmp/#{prefix}_csv_temp"
+    dest = ENV['ZIP'] || "#{prefix}_smoke.zip"
+    TraitBank::TraitsDumper.dump_clade(clade, dest, csvdir, limit)
   end
 
 end

--- a/lib/tasks/dump_traits.rake
+++ b/lib/tasks/dump_traits.rake
@@ -5,7 +5,7 @@ namespace :dump_traits do
   desc 'Dump traits information from neo4j graphdb into a set of .csv files.'
   task dump: :environment do
     clade = ENV['ID'] || '2913056'     # default = life
-    limit = ENV['LIMIT'] || 1000000
+    limit = ENV['LIMIT'] || '100000000'
     prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}"
     prefix = "#{prefix}_#{clade}" if ENV['ID']
     prefix = "#{prefix}_limit_#{limit}" if ENV['LIMIT']
@@ -21,8 +21,8 @@ namespace :dump_traits do
 
   desc 'Smoke test of traits dumper; finishes quickly.'
   task smoke: :environment do
-    clade = ENV['ID'] || 7662     # Carnivora
-    limit = ENV['LIMIT'] || 100
+    clade = ENV['ID'] || '7662'     # Carnivora
+    limit = ENV['LIMIT'] || '100'
     prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}_#{clade}_#{limit}"
     csvdir = ENV['CSVDIR'] || "/tmp/#{prefix}_csv_temp"
     dest = ENV['ZIP'] || "#{prefix}_smoke.zip"

--- a/lib/tasks/dump_traits.rake
+++ b/lib/tasks/dump_traits.rake
@@ -1,0 +1,27 @@
+# Purpose of this command: At the command line, generate a CSV file
+# dump of the entire trait graphdb.  See the associated support module.
+# This can also be used for partial dumps of particular clades.
+# To obtain csv files via the web service, use the format=csv option
+# for the appropriate web service.
+
+namespace :dump_traits do
+
+  desc 'Dump traits information from neo4j graphdb into a set of .csv files.'
+  task dump: :environment do
+    clade = ENV['ID'] ? ENV['ID'] : 2913056     # default = life
+    limit = ENV['LIMIT'] ? ENV['LIMIT'] : 1000000
+    TraitBank::TraitsDumper.dump_clade(clade,
+                                       "sample-dumps/#{clade}-csv",
+                                       limit)
+  end
+
+  desc 'Smoke test of traits dumper; finishes quickly.'
+  task smoke: :environment do
+    clade = ENV['ID'] ? ENV['ID'] : 7662     # Carnivora
+    limit = ENV['LIMIT'] ? ENV['LIMIT'] : 100
+    TraitBank::TraitsDumper.dump_clade(clade,
+                                       "sample-dumps/#{clade}-smoke-csv",
+                                       limit)
+  end
+
+end


### PR DESCRIPTION
Documentation in doc/trait-bank-dumps.rb

## What problem does this solve?

A number of parties have requested bulk downloads of the traits
database.  It is proposed to do offline dumps of the neo4j graphdb,
perhaps quarterly, and make them available to the public for download
as a .zip file.

## Pros and cons?

Pros: Parties will be somewhat happier.

Cons: There may be bugs in the overall dump process; somebody has to
be assigned to run the 'rake' command periodically on the server, and
they may forget.  Also, the dump may fail partway through for
unanticipated.

The code was written by someone with only a rudimentary knowledge of
ruby and rails.  A code review is highly recommended.

## How to test?

I don't think this PR can be tested on the production graphdb without
merging it to master, without significant additional work.

Tests to do in sequence (easier to harder):

  1. Smoke test: 
         `bundle exec rake dump_traits:smoke`
     - should write a file in the current directory whose name starts
       with 'traitbank_' and ends with _smoke.zip
     - size of file should be >= 7000 bytes and < 70000 bytes
     - you can delete the .zip file
  2. Carnivora:
         `time bundle exec rake ID=7662 ZIP=test1.zip dump_traits:dump`
     - email the time statistics to me or post them here
     - also tell me the size of the file
     - size of test1.zip should be >= 400000
     - you can delete test1.zip
  3. Vertebrates:
         `time bundle exec rake ID=2774383 ZIP=test2.zip dump_traits:dump`
     - IMPORTANT: email the time statistics to me or post them here
     - also tell me the size of the file
     - you can delete test1.zip
  4. All life:
         `time bundle exec rake ZIP=test3.zip dump_traits:dump`