### PR TITLE
Dump traits in parts

### DIFF
--- a/app/models/trait_bank.rb
+++ b/app/models/trait_bank.rb
@@ -32,7 +32,7 @@ class TraitBank
         results = connection.execute_query(q)
       ensure
         q.gsub!(/ +([A-Z ]+)/, "\n\\1") if q.size > 80 && q !~ /\n/
-        Rails.logger.warn(">>TB TraitBank (#{stop ? stop - start : "F"}):\n#{q}")
+        Rails.logger.info(">>TB TraitBank (#{stop ? stop - start : "F"}):\n#{q}")
       end
       results
     end
@@ -332,7 +332,7 @@ class TraitBank
         key = "trait_bank/term_search/counts/#{key}"
         if Rails.cache.exist?(key)
           count = Rails.cache.read(key)
-          Rails.logger.warn("&& TS USING cached count: #{key} = #{count}")
+          Rails.logger.info("&& TS USING cached count: #{key} = #{count}")
           return count
         end
       else
@@ -361,12 +361,12 @@ class TraitBank
       "#{limit_and_skip}"
       res = query(q)
 
-      Rails.logger.warn("&& TS SAVING Cache: #{key}")
+      Rails.logger.info("&& TS SAVING Cache: #{key}")
       if options[:count]
         raise "&& TS Lost key" if key.blank?
         count = res["data"] ? res["data"].first.first : 0
         Rails.cache.write(key, count, expires_in: 1.day)
-        Rails.logger.warn("&& TS SAVING Cached count: #{key} = #{count}")
+        Rails.logger.info("&& TS SAVING Cached count: #{key} = #{count}")
         count
       else
         Rails.logger.debug("RESULT COUNT #{key}: #{res["data"] ? res["data"].length : "unknown"} raw")

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,8 @@ module EolWebsite
       end
     end
 
+    # Search for classes in the lib directory
+    config.autoload_paths += %W(#{config.root}/lib)
+
   end
 end

--- a/doc/cypher.py
+++ b/doc/cypher.py
@@ -43,7 +43,7 @@ def doit(server, api_token, query, format):
         print >>sys.stderr, r.text
     else:
         sys.stderr.write('Unrecognized response content-type: %s\n' % ct)
-        print >>sys.stderr, r.text[0:1000]
+        print >>sys.stderr, r.text[0:10000]
         sys.exit(1)
     if r.status_code != 200:
         sys.exit(1)

--- a/doc/trait-bank-dumps.md
+++ b/doc/trait-bank-dumps.md
@@ -36,13 +36,6 @@ E.g.
     export CHUNK=50000
     ruby -r ./lib/traits_dumper.rb -e TraitsDumper.main
 
-## Via `rake` using neography
-
-The `dump_traits` family of `rake` commands is intended to create
-Traitbank dumps, which anyone can download, from the main web site or
-from the opendata site (depending on how we eventually decide to
-deploy them).
-
 At present (October 2018) the scripts are driven entirely from the
 neo4j graphdb.  This is based on the hypothesis that when people say
 they want "all the traits", then all the information they need will be
@@ -50,6 +43,18 @@ present in the graphdb, not the MySQL database.  If they need other
 tables (e.g. synonyms or vernaculars from the MySQL database), they
 will be able to get them in some other way.  I don't know if this is
 true; there may be more work to do here.
+
+## Via `rake` using neography
+
+The `dump_traits` family of `rake` commands is intended to create
+Traitbank dumps, which anyone can download, from the main web site or
+from the opendata site (depending on how we eventually decide to
+deploy them).
+
+The script may terminate complaining of a 502 or 504 status code from
+the server, or for some other reason.  In this case just rerun the
+command.  Results from the previous attempt (left over in `/tmp`) will
+be reused to reduce traffic to the server.
 
 ### `dump_traits:dump`
 

--- a/lib/tasks/dump_traits.rake
+++ b/lib/tasks/dump_traits.rake
@@ -18,7 +18,7 @@ namespace :dump_traits do
       dest = TraitBank::DataDownload.path.join("#{prefix}.zip")
     end
     TraitsDumper.dump_clade(clade, dest, csvdir, chunksize,
-                            TraitBank::query)
+                            Proc.new {|cql| TraitBank::query(cql)})
   end
 
   desc 'Smoke test of traits dumper; finishes quickly.'

--- a/lib/tasks/dump_traits.rake
+++ b/lib/tasks/dump_traits.rake
@@ -12,27 +12,20 @@ namespace :dump_traits do
     chunksize = ENV['CHUNK']
     csvdir = ENV['CSVDIR']
     dest = ENV['ZIP']
-    unless dest
-      prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}"
-      prefix = "#{prefix}_#{clade}" if clade
-      dest = TraitBank::DataDownload.path.join("#{prefix}.zip")
-    end
-    TraitsDumper.dump_clade(clade, dest, csvdir, chunksize,
-                            Proc.new {|cql| TraitBank::query(cql)})
+    TraitsDumper.dump_clade(clade, csvdir, chunksize,
+                            Proc.new {|cql| TraitBank::query(cql)},
+                            dest)
   end
 
   desc 'Smoke test of traits dumper; finishes quickly.'
   task smoke: :environment do
     clade = ENV['ID'] || '7674'     # Felidae
-    chunksize = ENV['CHUNK'] || '100'
+    chunksize = ENV['CHUNK'] || '1000'
     csvdir = ENV['CSVDIR']
     dest = ENV['ZIP']
-    unless dest
-      prefix = "traitbank_#{DateTime.now.strftime("%Y%m%d")}_#{clade}_#{chunksize}"
-      dest = "#{prefix}_smoke.zip"
-    end
-    TraitsDumper.dump_clade(clade, dest, csvdir, chunksize,
-                            TraitBank::query)
+    TraitsDumper.dump_clade(clade, csvdir, chunksize,
+                            Proc.new {|cql| TraitBank::query(cql)},
+                            dest)
   end
 
 end

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -1,18 +1,12 @@
+# ID=7674 CHUNK=20000 TOKEN=`cat ../api.token` ZIP=felidae.zip ruby -r ./lib/traits_dumper.rb -e TraitsDumper.main
+# (7674 is Felidae)
+
 # Generate CSV files expressing trait information for a single taxon
 # recursively.
 
-# For the future, in case we decide to query by predicate:
-=begin
- MATCH (term:Term)
- WHERE term.type = "measurement"
- OPTIONAL MATCH (term)-[:parent_term]->(parent:Term) 
- WHERE parent.uri IS NULL
- RETURN term.uri, term.name
- LIMIT 1000
-=end
-
 require 'csv'
 require 'fileutils'
+require 'zip'
 
 # These are required if we want to be an HTTP client:
 require 'net/http'
@@ -57,10 +51,12 @@ class TraitsDumper
   end
 
   def doit
-    write_zip [emit_pages,
-               emit_traits,
-               emit_metadatas,
-               emit_terms]
+    predicates = list_predicates
+    STDERR.puts "#{predicates.length} predicate URIs"
+    write_zip [emit_terms,
+               emit_pages,
+               emit_traits(predicates),
+               emit_metadatas(predicates)]
   end
 
   # There is probably a way to do this without creating the temporary
@@ -91,7 +87,35 @@ class TraitsDumper
     end
   end
 
-  #---- Query #3: Pages
+  #---- Query: Predicates (subset of Terms)
+
+  def list_predicates
+    predicates_query =
+     'MATCH (term:Term {type: "measurement"})
+      RETURN term.uri
+      LIMIT 10000'
+    run_query(predicates_query)["data"]
+  end
+
+  #---- Query: Terms
+
+  def emit_terms
+
+    # Many Term nodes have 'uri' properties that are not URIs.  Would it 
+    # be useful to filter those out?  It's about 2% of the nodes.
+
+    # I'm not sure where there exist multiple Term nodes for a single URI?
+
+    terms_query =
+     "MATCH (r:Term)
+      OPTIONAL MATCH (r)-[:parent_term]->(parent:Term)
+      RETURN r.uri, r.name, r.type, parent.uri
+      ORDER BY r.uri"
+    terms_keys = ["uri", "name", "type", "parent_uri"]
+    supervise_query(terms_query, terms_keys, "terms.csv")
+  end
+
+  #---- Query: Pages (taxa)
 
   def emit_pages
     pages_query =
@@ -103,9 +127,9 @@ class TraitsDumper
     supervise_query(pages_query, pages_keys, "pages.csv")
   end
 
-  #---- Query #2: Traits
+  #---- Query: Traits (trait records)
 
-  def emit_traits
+  def emit_traits(predicates)
 
     traits_query =
      "MATCH (t:Trait)<-[:trait]-(page:Page)
@@ -136,9 +160,9 @@ class TraitsDumper
     supervise_query(traits_query, traits_keys, "traits.csv")
   end
 
-  #---- Query #1: Metadatas
+  #---- Query: Metadatas
 
-  def emit_metadatas
+  def emit_metadatas(predicates)
 
     metadata_query = 
      "MATCH (m:MetaData)<-[:metadata]-(t:Trait),
@@ -155,107 +179,104 @@ class TraitsDumper
     supervise_query(metadata_query, metadata_keys, "metadata.csv")
   end
 
-  #---- Query #0: Terms
-
-  def emit_terms
-
-    # Many Term nodes have 'uri' properties that are not URIs.  Would it 
-    # be useful to filter those out?  It's about 2% of the nodes.
-
-    # I'm not sure where there exist multiple Term nodes for a single URI?
-
-    terms_query =
-     "MATCH (r:Term)
-      OPTIONAL MATCH (r)-[:parent_term]->(parent:Term)
-      RETURN r.uri, r.name, r.type, parent.uri
-      ORDER BY r.uri"
-    terms_keys = ["uri", "name", "type", "parent_uri"]
-    supervise_query(terms_query, terms_keys, "terms.csv")
-  end
-
   # -----
 
-  # filename is relative to @csvdir
+  # supervise_query
+  # The purpose is to create a .csv file for a particular table (traits, pages, etc.).
+
+  # The result sets are too big to capture with a single query, due to
+  # timeouts or other problems, so the query is applied many times
+  # to get "chunks" of results.
+
+  # Each chunk is placed in a file.  If a chunk file already exists
+  # the query is not repeated - the results from the previous run are
+  # used directly without verification.
+
+  # filename (where to put the .csv file) is interpreted relative to @csvdir
 
   def supervise_query(query, columns, filename)
     path = File.join(@csvdir, filename)
     if File.exist?(path)
       STDERR.puts "reusing previously created #{path}"
     else
-      # Create a directory filename.parts to hold the parts
-      parts_dir = path + ".parts"
-
-      if @chunksize
-        limit_phrase = "LIMIT #{@chunksize}"
-      else
-        limit_phrase = ""
-      end
-
-      parts = []
-      skip = 0
-      while true
-        # Fetch it in parts
-        part = File.join(parts_dir, "#{skip}.csv")
-        if File.exist?(part)
-          STDERR.puts "reusing previously created #{part}"
-          parts.push(part)
-          # TBD: we should increase skip by the actual number of
-          # records in the file.
-          skip += @chunksize if @chunksize
-        else
-          result = query(query + " SKIP #{skip} #{limit_phrase}")
-          # A null result means that there was some kind of error, which
-          # has already been reported.  (because I don't want to learn
-          # ruby exception handling!)
-          got = result["data"].length
-          if result and got > 0
-            emit_csv(result, columns, part)
-            parts.push(part)
-          end
-          skip += got
-          break if @chunksize and got < @chunksize
-        end
-        break unless @chunksize
-      end
-
-      # Concatenate all the parts together
-      if parts.size == 0
-        nil
-      elsif parts.size == 1
-        FileUtils.mv parts[0], path
-        path
-      else
-        temp = path + ".new"
-        if false
-          # The 'tail' man page is wrong; it says the +2 should follow -q, but the
-          # command barfs if you do it that way.
-          # Also, the 'tail' command fails when there are lots of files.
-          # 'gtail' doesn't have this bug.  (could 'map' to work around.)
-          more_files = parts.drop(1).join(' ')
-          more = "tail +2 -q #{more_files}"
-        elsif false
-          # Use gnu 'tail' (might or might not be available under the name 'gtail')
-          more_files = parts.drop(1).join(' ')
-          more = "gtail -n +2 -q #{more_files}"
-        else
-          # This version is a bit slower, but not too much, and it's
-          # not sensitive to vagaries of various 'tail' commands.
-          tails = parts.drop(1).map { |path| "tail +2 #{path}" }
-          more = tails.join(';')
-        end
-        command = "(cat #{parts[0]}; #{more}) >#{temp}"
-        STDERR.puts(command)
-        system command
-        FileUtils.mv temp, path
-        STDERR.puts("#{File.basename(path)}: #{skip} records")
-        path
-      end
+      parts, count = obtain_parts(query, columns, path)
+      assemble_parts(parts, count, path)
     end
   end
 
-  def query(cql)
+  # Ensure that all the parts files for a table exist, using Neo4j to
+  # obtain them as needed.
+  # Returns a list of paths (file names for the parts) and a count of
+  # the total number of records.
+
+  def obtain_parts(query, columns, path)
+
+    # Create a directory path.parts to hold the parts
+    parts_dir = path + ".parts"
+
+    if @chunksize
+      limit = "#{@chunksize}"
+    else
+      limit = "10000000"
+    end
+
+    parts = []
+    skip = 0
+    while true
+      # Fetch it in parts
+      part = File.join(parts_dir, "#{skip}.csv")
+      if File.exist?(part)
+        STDERR.puts "reusing previously created #{part}"
+        parts.push(part)
+        # TBD: we should increase skip by the actual number of
+        # records in the file.
+        skip += @chunksize if @chunksize
+      else
+        result = run_query(query + " SKIP #{skip} LIMIT #{limit}")
+        # A null result means that there was some kind of error, which
+        # has already been reported.  (because I don't want to learn
+        # ruby exception handling!)
+        got = result["data"].length
+        if result and got > 0
+          emit_csv(result, columns, part)
+          parts.push(part)
+        end
+        skip += got
+        break if @chunksize and got < @chunksize
+      end
+      break unless @chunksize
+    end
+    [parts, skip]
+  end
+
+  # Combine the parts files (for a single table) into a single master .csv file
+
+  def assemble_parts(parts, count, path)
+    # Concatenate all the parts together
+    if parts.size == 0
+      nil
+    elsif parts.size == 1
+      FileUtils.mv parts[0], path
+      path
+    else
+      temp = path + ".new"
+      tails = parts.drop(1).map { |path| "tail +2 #{path}" }
+      more = tails.join(';')
+      command = "(cat #{parts[0]}; #{more}) >#{temp}"
+      system command
+      FileUtils.mv temp, path
+      STDERR.puts("#{File.basename(path)}: #{parts.length} parts, #{count} records")
+      path
+    end
+  end
+
+  # Run a single CQL query using method provided
+
+  def run_query(cql)
     @query_fn.call(cql)
   end
+
+  # Method for doing queries using EOL v3 API via HTTP
 
   def self.query_via_http(server, token, cql)
     # Need to be a web client.
@@ -276,7 +297,7 @@ class TraitsDumper
     end
   end
 
-  # Utility
+  # Utility - convert native cypher output form to CSV
   def emit_csv(start, keys, path)
 
     # Sanity check the result

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -38,8 +38,9 @@ class TraitsDumper
     server = ENV['SERVER'] || "https://eol.org/"
     token = ENV['TOKEN'] || STDERR.puts("** No TOKEN provided")
     dest = ENV['ZIP']
-    new(clade,                 # clade
-        nil, # temp dir = where to put intermediate csv files - form via default rule
+    tempdir = ENV['TEMP']
+    new(clade,      # clade or nil
+        tempdir,    # temp dir = where to put intermediate csv files
         chunksize,                 # chunk size (for LIMIT and SKIP clauses)
         Proc.new {|cql| query_via_http(server, token, cql)}).dump_traits(dest)
   end

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -198,19 +198,20 @@ class TraitsDumper
     end
     metadata_keys = ["eol_pk", "trait_eol_pk", "predicate", "value_uri",
                      "measurement", "units_uri", "literal"]
-    predicates = list_metadata_predicates
-    STDERR.puts "#{predicates.length} metadata predicate URIs"
+    trait_predicates = list_trait_predicates
+    STDERR.puts "#{trait_predicates.length} trait predicate URIs"
     files = []
-    for i in 0..predicates.length do
-      predicate = predicates[i]
-      next if is_attack?(predicate)
-      STDERR.puts "#{i} #{predicate}" if i % 25 == 0
+    for i in 0..trait_predicates.length do
+      trait_predicate = trait_predicates[i]
+      next if is_attack?(trait_predicate)
+      STDERR.puts "#{i} #{trait_predicate}" if i % 25 == 0
       metadata_query = 
        "MATCH (m:MetaData)<-[:metadata]-(t:Trait),
               (t)<-[:trait]-(page:Page)
               #{transitive_closure_part}
         WHERE page.canonical IS NOT NULL
-        MATCH (m)-[:predicate]->(predicate:Term {uri: '#{predicate}'})
+        MATCH (m)-[:predicate]->(predicate:Term),
+              (t)-[:predicate]->(trait_predicate:Term {uri: '#{trait_predicate}'})
         OPTIONAL MATCH (m)-[:object_term]->(obj:Term)
         OPTIONAL MATCH (m)-[:units_term]->(units:Term)
         RETURN m.eol_pk, t.eol_pk, predicate.uri, obj.uri, m.measurement, units.uri, m.literal"

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -3,7 +3,7 @@
 
 # For the future, in case we decide to query by predicate:
 =begin
-MATCH (term:Term)
+ MATCH (term:Term)
  WHERE term.type = "measurement"
  OPTIONAL MATCH (term)-[:parent_term]->(parent:Term) 
  WHERE parent.uri IS NULL
@@ -49,12 +49,13 @@ class TraitsDumper
     @csvdir = csvdir
     unless @csvdir
       prefix = "traitbank_#{DateTime.now.strftime("%Y%m")}"
-      prefix = "#{prefix}_#{clade}" if @clade
+      prefix = "#{prefix}_#{@clade}" if @clade
       prefix = "#{prefix}_chunked_#{chunksize}" if @chunksize
       @csvdir = "/tmp/#{prefix}_csv_temp"
     end
     @query_fn = query_fn
   end
+
   def doit
     write_zip [emit_pages,
                emit_traits,

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -63,19 +63,20 @@ class TraitsDumper
   # This method is suitable for invocation from the shell via
   #  ruby -r "./lib/traits_dumper.rb" -e "TraitsDumper.main"
   def self.main
-    clade = ENV['ID']           # possibly nil
-    chunksize = ENV['CHUNK']    # possibly nil
-    tempdir = ENV['TEMP']      # temp dir = where to put intermediate csv files
-    dest = ENV['ZIP']
     server = ENV['SERVER'] || "https://eol.org/"
     token = ENV['TOKEN'] || STDERR.puts("** No TOKEN provided")
     query_fn = Proc.new {|cql| query_via_http(server, token, cql)}
+
+    clade = ENV['ID']           # possibly nil
+    tempdir = ENV['TEMP']      # temp dir = where to put intermediate csv files
+    chunksize = ENV['CHUNK']    # possibly nil
+    dest = ENV['ZIP']
     new(clade, tempdir, chunksize, query_fn).dump_traits(dest)
   end
 
   # This method is suitable for use from a rake command.
 
-  def self.dump_clade(clade_page_id, dest, tempdir, chunksize, query_fn)
+  def self.dump_clade(clade_page_id, tempdir, chunksize, query_fn, dest)
     new(clade_page_id, tempdir, chunksize, query_fn).dump_traits(dest)
   end
 
@@ -88,14 +89,14 @@ class TraitsDumper
   # executing CQL queries.
 
   def initialize(clade_page_id, tempdir, chunksize, query_fn)
-    @chunksize = Integer(chunksize) if chunksize
-    # If clade_page_id is nil, that means do not filter by clade
     @clade = (clade_page_id ? Integer(clade_page_id) : nil)
     @tempdir = tempdir || File.join("/tmp", default_basename(@clade))
+    @chunksize = Integer(chunksize) if chunksize
+    # If clade_page_id is nil, that means do not filter by clade
     @query_fn = query_fn
   end
 
-  # dest is name of zip file to be written
+  # dest is name of zip file to be written, or nil for default
   def dump_traits(dest)
     paths = [emit_terms,
              emit_pages,

--- a/lib/traits_dumper.rb
+++ b/lib/traits_dumper.rb
@@ -205,6 +205,7 @@ class TraitsDumper
     if fails.empty?
       assemble_chunks(files, path)
     else
+      STDERR.puts "** Deferred due to exception(s): traits.csv"
       nil
     end
   end
@@ -264,6 +265,7 @@ class TraitsDumper
     if fails.empty?
       assemble_chunks(files, path)
     else
+      STDERR.puts "** Deferred due to exception(s): metadata.csv"
       nil
     end
   end


### PR DESCRIPTION
This PR improves the all-traits dump so that it can get trait records using lots of small cypher queries, so that neo4j timeouts are avoided.

(This is not entirely successful; the for `Present` query, we still need a longer timeout, maybe 5 minutes?)

There is recovery logic, so that if the script fails due to timeout or any other reason, it can be run a second time (after reconfiguring the timeout, or taking other action), and partial results from previous attempts are reused.

As before, the script can run either as a rake task (using neography) or from the shell (using the web API).  Documentation in `doc/trait-bank-dumps.md` and in `lib/traits_dumper.rb`.