### PR TITLE
Authorize admin in api

### DIFF
--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -8,38 +8,50 @@ class Service::CypherController < ServicesController
   def form
     # Cf. the view
   end
-
+  
   def query
-    cypher = params[:query]
-    return render_bad_request(title: "Missing a 'query' parameter.") \
-      unless cypher != nil
+    format = params.delete(:format) || "cypher"
 
-    format = params[:format]
-    format = "cypher" unless format != nil
+    cypher = params.delete(:query])
+    return render_bad_request(title: "Missing a 'query' parameter.") unless
+      cypher != nil
 
-    # Authenticate the user and authorize the requested operation, using
-    # the API token and the user's information in the table.
-    # Non-admin users are not supposed to modify the database.  The following
-    # regex is an ad hoc filter to try to prevent this, at least when it is 
-    # accidental; one shouldn't expect it to be secure against a concerted attack.
+    # Deletion is forbidden in order to help prevent catastrophic
+    # mistakes.
     # The purpose of the 'limit' is to help prevent unintended DoS 
     # attacks.
-    if cypher =~ /\b(delete|create|set|remove|merge|call|drop|load)\b/i
+    # The regexes below are ad hoc filters to try to prevent problems,
+    # at least when accidental.  We don't expect these permission
+    # checks to provide security against a concerted attack.
+
+    return render_bad_request(title: "Please provide a LIMIT clause") unless
+      cypher =~ /\b(limit)\b/i
+    return render_bad_request(title: "Cypher operation not permitted via service") if
+      cypher =~ /\b(delete|remove|call)\b/i
+      
+    # Authenticate the user and authorize the requested operation, 
+    # using the API token and the information in the user table.
+    # Non-admin users are not supposed to add to the database.
+    
+    if cypher =~ /\b(create|set|merge|load)\b/i
+      # Allow admin to add to graph
       user = authorize_admin_from_token!
-    elsif cypher =~ /\b(limit)\b/i
-      user = authorize_user_from_token!    # power user that is
     elsif
-      user = authorize_admin_from_token!
+      # Power users can only read
+      user = authorize_user_from_token!
     end
     return nil unless user
 
     # Do the query or command
+    render_results(TraitBank.query(cypher), format)
+  end
+
+  def render_results(results, format)
     case format
     when "cypher" then
-      render json: TraitBank.query(cypher)
+      render json: results
     when "csv" then
       self.content_type = 'text/csv'
-      results = TraitBank.query(cypher)
       # Streaming output
       self.response_body =
         Enumerator.new do |y|
@@ -52,6 +64,25 @@ class Service::CypherController < ServicesController
       return render_bad_request(title: "Unrecognized 'format' parameter value.", format: format)
     end        # end case
   end          # end def
+
+  def remove_relationships
+    format = params[:format] || "cypher"
+
+    relation = Integer(params[:relation])
+    # Fixed set of allowed relationships
+    return render_bad_request(title: "Unrecognized relation #{relation}") unless
+      ["inferred_trait"].include?(relation)
+
+    resource_id = Integer(params[:resource_id])
+    authorize_admin_from_token!
+    render_results(TraitBank.query(
+                    'MATCH ()-[rel:#{relation}]-
+                           (t:Trait)-[:supplier]->
+                           (:Resource {resource_id: #{resource_id}})
+                     DELETE rel
+                     RETURN t.resource_pk'))
+  end
+
 end            # end class
 
 

--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -6,42 +6,47 @@ class Service::CypherController < ServicesController
   before_action :require_power_user, only: :form
 
   def form
+    # Cf. the view
   end
 
   def query
-    return unless authorize_user_from_token!
     cypher = params[:query]
     format = params[:format]
     format = "cypher" unless format != nil
 
-    if cypher == nil
-      render_bad_request(title: "Missing a 'query' parameter.")
+    return render_bad_request(title: "Missing a 'query' parameter.") \
+      unless cypher != nil
 
-    # Web users are not supposed to modify the database.  The following
+    # Non-admin users are not supposed to modify the database.  The following
     # is an ad hoc filter to try to prevent this, at least when it is 
     # accidental; one shouldn't expect it to be secure against a concerted attack.
-    elsif cypher =~ /\b(delete|create|set|remove|merge|call|drop|load)\b/i
-      render_unauthorized(title: "You are not authorized to use this Cypher command.")
-    elsif cypher =~ /\b(limit)\b/i
-      case format
-      when "cypher" then
-        render json: TraitBank.query(cypher)
-      when "csv" then
-        self.content_type = 'text/csv'
-        results = TraitBank.query(cypher)
-        # Streaming output
-        self.response_body =
-          Enumerator.new do |y|
-            y << CSV.generate_line(results["columns"])
-            results["data"].each do |row|
-              y << CSV.generate_line(row)
-            end
-          end    # end Enumerator
-      else
-        render_bad_request(title: "Unrecognized 'format' parameter value.", format: format)
-      end        # end case
+    if cypher =~ /\b(delete|create|set|remove|merge|call|drop|load)\b/i ||
+       cypher =~ /\b(limit)\b/i
+      return unless authorize_admin_from_token!
     else
-      render_unauthorized(title: "You must specify a LIMIT for this operation.")
+      return unless authorize_user_from_token!
     end
-  end
-end
+
+    # Do the query or command
+    case format
+    when "cypher" then
+      render json: TraitBank.query(cypher)
+    when "csv" then
+      self.content_type = 'text/csv'
+      results = TraitBank.query(cypher)
+      # Streaming output
+      self.response_body =
+        Enumerator.new do |y|
+          y << CSV.generate_line(results["columns"])
+          results["data"].each do |row|
+            y << CSV.generate_line(row)
+          end
+        end    # end Enumerator
+    else
+      return render_bad_request(title: "Unrecognized 'format' parameter value.", format: format)
+    end        # end case
+  end          # end def
+end            # end class
+
+
+

--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -12,7 +12,7 @@ class Service::CypherController < ServicesController
   def query
     format = params.delete(:format) || "cypher"
 
-    cypher = params.delete(:query])
+    cypher = params.delete(:query)
     return render_bad_request(title: "Missing a 'query' parameter.") unless
       cypher != nil
 

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,12 +10,14 @@ class ServicesController < ApplicationController
   # **** make sure that it gets done in the authorize_user_from_token!
   # **** method?  No, better to fail fast.
 
+  # User-facing method for creating a token.
+
   def authenticate_service
     # User needs to be logged in already!
     # Future: provide an automated service so scripts can fetch a token.
     # n.b. token only gives access to services, not to the rest of the
     # web site.
-    if current_user
+    if current_user     # inherited from application_controller
       if current_user.is_power_user?
         render json: {token: jwt_token(current_user)}
       else
@@ -28,83 +30,78 @@ class ServicesController < ApplicationController
 
   protected
 
-  # Authorize user for subsequent action if power user
+  # Authorize user for subsequent action if power user.
+  # Returns user on success, nil on failure.
 
   def authorize_user_from_token!
     user = authenticate_user_from_token!
-    if user
-      return render_unauthorized title: "Power user status is required for this operation." \
-        unless user.is_power_user?    # Unauthorized
-      @current_user = user
+    return nil unless user
+    if user.is_power_user?
+      user
+    else
+      render_unauthorized title: "Power user status is required for this operation."
+      nil
     end
   end
 
   def authorize_admin_from_token!
     user = authenticate_user_from_token!
-    if user
-      return render_unauthorized title: "Admin status is required for this operation." \
-        unless user.is_admin?      # Unauthorized
-      @current_user = user
+    return nil unless user
+    if user.is_admin?
+      user
+    else
+      render_unauthorized title: "Admin status is required for this operation."
+      nil
     end
   end
 
-  # No args - act as a guard on any web service action that wants authentication
+  # No args - act as a guard on any web service action that wants authentication.
   # We check the encrypted_password in order to implement token retraction:
   # if the user changes their password, they will have to get a new token.
-  # Returns user on success, nil (after render) on failure.
+  # Returns user on success, nil on failure after rendering an error report.
 
   def authenticate_user_from_token!
-    if current_user
-      return render_unauthorized title: "You are not authorized to use the web services." \
-         unless current_user.is_power_user?    # Unauthorized
-      @current_user = current_user
+    the_claims = parse_claims
+    return nil unless the_claims
+    user = User.find_by_email(the_claims[0]['user'])
+    # Valid email?
+    # Password from time of token creation still current?
+    if user && the_claims[0]['encrypted_password'] == user.encrypted_password
+      user
     else
-      diagnostic = check_claims
-      if diagnostic
-        return render_unauthenticated title: diagnostic
-      else
-        the_claims = claims
-        user = User.find_by_email(the_claims[0]['user'])
-        return render_unauthenticated title: "Invalid token." \
-          unless user          # ill-formed token
-        if user &&
-           the_claims[0]['encrypted_password'] == user.encrypted_password
-          user
-        end
-      end
+      render_unauthenticated title: "No such user, or token has been retracted."
+      nil
     end
   end
 
-  # Return the 'claims' or nil if not authorized
-  def claims
-    parts = request.headers['Authorization'].split
-    ::TokenAuthentication.decode(parts[1])
-  end
-
+  # Returns nil on failure, syntactically correct claims on success.
   # TBD: tests for all these cases... I've done them manually
 
-  # Explain why authentication ('claims' above) would fail (if it would).
-  def check_claims
+  def parse_claims
+    # Check for presence of HTTP header
     auth_header = request.headers['Authorization']
-    if auth_header
-      parts = auth_header.split
-      if parts.size != 2
-        "Expected Authorization header to have two parts, saw #{parts.size}: #{auth_header}"
-      elsif parts[0] != 'JWT'
-        "Expected Authorization header to start 'JWT', saw #{parts[0]}: #{auth_header}"
-      else
-        begin
-          # Throw exception on failure; return nil on success
-          ::TokenAuthentication.decode(parts[1])
-          nil
-        rescue JWT::DecodeError => e
-          "JWT decode error in Authorization header: #{e}: #{parts[1]}"
-        end
-      end
-    else
-      "No Authorization header"
+    if not auth_header
+      render_unauthenticated title: "No Authorization header"
+      nil
     end
-  # Rohit had `rescue nil` here
+    # See if header value splits into two parts
+    parts = auth_header.split
+    if parts.size != 2
+      render_unauthenticated title: "Expected Authorization header to have two parts, saw #{parts.size}: #{auth_header}"
+      nil
+    end
+    # Part 0 has to be 'JWT'
+    if parts[0] != 'JWT'
+      render_unauthenticated title: "Expected Authorization header to start 'JWT', saw #{parts[0]}: #{auth_header}"
+      nil
+    end
+    # Decode the token
+    begin
+      claims = ::TokenAuthentication.decode(parts[1])
+    rescue JWT::DecodeError => e
+      render_unauthenticated title: "JWT decode error in Authorization header: #{e}: #{parts[1]}"
+    end
+    claims
   end
 
   # Aux

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -82,24 +82,25 @@ class ServicesController < ApplicationController
     auth_header = request.headers['Authorization']
     if not auth_header
       render_unauthenticated title: "No Authorization header"
-      nil
+      return nil
     end
     # See if header value splits into two parts
     parts = auth_header.split
     if parts.size != 2
       render_unauthenticated title: "Expected Authorization header to have two parts, saw #{parts.size}: #{auth_header}"
-      nil
+      return nil
     end
     # Part 0 has to be 'JWT'
     if parts[0] != 'JWT'
       render_unauthenticated title: "Expected Authorization header to start 'JWT', saw #{parts[0]}: #{auth_header}"
-      nil
+      return nil
     end
     # Decode the token
     begin
       claims = ::TokenAuthentication.decode(parts[1])
     rescue JWT::DecodeError => e
       render_unauthenticated title: "JWT decode error in Authorization header: #{e}: #{parts[1]}"
+      return nil
     end
     claims
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,7 @@ Rails.application.routes.draw do
     get "/services/authenticate" => "services#authenticate_service"
     get "/service/cypher" => "service/cypher#query", as: "cypher_query"
     get "/service/cypher_form" => "service/cypher#form", as: "cypher_form"
+    get "/service/remove_relationships" => "service/cypher#remove_relationships", as: "remove_relationships"
 
     post "/collected_pages_media" => "collected_pages_media#destroy", :as => "destroy_collected_pages_medium"
 


### PR DESCRIPTION
This change allows API services (such as query) to require the authenticated user to be an admin user, for operations that require that (e.g. modifying the graphdb).

I had a hard time understanding the token parsing and authentication logic, so I made some changes to it for comprehensibility. (Previous code showed too much influence of the tutorial I consulted.) I think I've tested it adequately, famous last words.

Admin users can now use the query service to do MERGE operations, do queries without LIMIT, and so on.