### PR TITLE
Authorize admin for delete

### DIFF
--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -24,23 +24,22 @@ class Service::CypherController < ServicesController
     # at least when accidental.  We don't expect these permission
     # checks to provide security against a concerted attack.
 
-    return render_bad_request(title: "Please provide a LIMIT clause") unless
+    return render_bad_request(title: "Please provide a LIMIT clause.") unless
       cypher =~ /\b(limit)\b/i
-    return render_bad_request(title: "Cypher operation not permitted via service") if
-      cypher =~ /\b(delete|remove|call)\b/i
       
     # Authenticate the user and authorize the requested operation, 
     # using the API token and the information in the user table.
     # Non-admin users are not supposed to add to the database.
     
-    if cypher =~ /\b(create|set|merge|load)\b/i
-      # Allow admin to add to graph
+    if cypher =~ /\b(create|set|merge|load|delete|remove|call)\b/i
+      # Allow admin to add to graph and perform dangerous operations
       user = authorize_admin_from_token!
+      return nil unless user
     elsif
       # Power users can only read
       user = authorize_user_from_token!
+      return nil unless user
     end
-    return nil unless user
 
     # Do the query or command
     render_results(TraitBank.query(cypher), format)

--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -35,7 +35,7 @@ class Service::CypherController < ServicesController
       # Allow admin to add to graph and perform dangerous operations
       user = authorize_admin_from_token!
       return nil unless user
-    elsif
+    else
       # Power users can only read
       user = authorize_user_from_token!
       return nil unless user
@@ -93,3 +93,35 @@ end            # end class
 
 
 
+=begin
+
+I didn't know where to put tests, and these take a bit of setup, so
+rather than lose what might have been useful work (they did help me
+find bugs), I'm just dumping the tests here in this comment. -JAR
+
+Create three users with different authorization levels:
+
+bin/rails r 'user = User.create!({email: "qwy103@mumble.net", username: "eol3", password: "x", role: :user}); user.activate'
+bin/rails r 'user = User.create!({email: "qwy104@mumble.net", username: "eol4", password: "x", role: :power_user}); user.activate'
+bin/rails r 'user = User.create!({email: "qwy105@mumble.net", username: "eol5", password: "x", role: :admin}); user.activate'
+
+Get the tokens for the three users:
+
+bin/rails r 'puts(ServicesController.jwt_token(User.where(email: "qwy103@mumble.net").last))'
+bin/rails r 'puts(ServicesController.jwt_token(User.where(email: "qwy104@mumble.net").last))'
+bin/rails r 'puts(ServicesController.jwt_token(User.where(email: "qwy105@mumble.net").last))'
+
+Test all nine combinations of auth level + request class:
+
+for auth in varela-user varela varela-admin; do
+  for query in "MATCH (p:Page) RETURN p.page_id" \
+               "MATCH (p:Page) RETURN p.page_id LIMIT 2" \
+               "MATCH (p:Page {page_id:0}) DELETE (p) RETURN p.page_id LIMIT 2"; do
+    echo "### Test $auth"
+    python3 doc/cypher.py --format csv \
+            --server http://127.0.0.1:3000/ --tokenfile ~/Sync/eol/$auth.token \
+            --query "$query"
+  done
+done
+
+=end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -28,6 +28,16 @@ class ServicesController < ApplicationController
     end
   end
 
+  # Get authentication token for a given user.
+  # The purpose of the password is just to cause tokens
+  # to stop working when the user's password changes.
+  # This method can be used from scripts, e.g.
+  # bin/rails r 'puts(ServicesController.jwt_token(User.where(email: "qwy103@mumble.net").last))'
+  def self.jwt_token(user)
+    TokenAuthentication.encode({'user' => user.email,
+                                'encrypted_password' => user.encrypted_password})
+  end
+
   protected
 
   # Authorize user for subsequent action if power user.
@@ -36,7 +46,7 @@ class ServicesController < ApplicationController
   def authorize_user_from_token!
     user = authenticate_user_from_token!
     return nil unless user
-    if user.is_power_user?
+    if user.is_power_user?   # power user or admin
       user
     else
       render_unauthorized title: "Power user status is required for this operation."
@@ -108,14 +118,6 @@ class ServicesController < ApplicationController
       return nil
     end
     claims
-  end
-
-  # Aux
-  # The purpose of the password is just to cause tokens
-  # to stop working whenever the user's password changes.
-  def jwt_token(user)
-    TokenAuthentication.encode({'user' => user.email,
-                                'encrypted_password' => user.encrypted_password})
   end
 
   # The form of the payload is up for redesign; probably someone has


### PR DESCRIPTION
This looks like a lot of changes but most are inconsequential: comments, minor reorg, test support. The significant changes are:

 - Allow admin users to do all Cypher operations, including ones like `DELETE` that we had prevented in the previous iteration
 - Fixed an obscure authorization error (if a power user got demoted to ordinary user, they were still able to use the cypher service) (this was just me writing `elsif` where I should have said `else`)