### PR TITLE
Fix token authenitcation; also LOAD CSV is not a dangerous operation

### DIFF
--- a/app/controllers/service/cypher_controller.rb
+++ b/app/controllers/service/cypher_controller.rb
@@ -31,7 +31,7 @@ class Service::CypherController < ServicesController
     # using the API token and the information in the user table.
     # Non-admin users are not supposed to add to the database.
     
-    if cypher =~ /\b(create|set|merge|load|delete|remove|call)\b/i
+    if cypher =~ /\b(create|set|merge|delete|remove|call)\b/i
       # Allow admin to add to graph and perform dangerous operations
       user = authorize_admin_from_token!
       return nil unless user

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -19,7 +19,7 @@ class ServicesController < ApplicationController
     # web site.
     if current_user     # inherited from application_controller
       if current_user.is_power_user?
-        render json: {token: jwt_token(current_user)}
+        render json: {token: ServicesController::jwt_token(current_user)}
       else
         render_unauthorized title: "You are not authorized to use the web services."
       end


### PR DESCRIPTION
The `services/authenticate` service was failing due to a mistake in a call to the `jwt_token` method; I hope this is fixed with this PR.

Also, I've removed LOAD from the list of dangerous cypher commands, since it is not in fact dangerous, as far as I can tell. (It might be unsafe if there were a bug in neo4j's CSV loaded that allowed for arbitrary code execution or something like that, but that seems really unlikely.)