### PR TITLE
rename one of the Repository classes to avoid conflict

### DIFF
--- a/app/models/content_server_connection.rb
+++ b/app/models/content_server_connection.rb
@@ -1,4 +1,4 @@
-class RepositoryHandle
+class ContentServerConnection
   def initialize(resource, log = nil)
     @resource = resource
     repo_url = Rails.application.secrets.repository[:url]

--- a/app/models/publishing/fast.rb
+++ b/app/models/publishing/fast.rb
@@ -33,7 +33,7 @@ class Publishing::Fast
   def initialize(resource, log = nil)
     @start_at = Time.now
     @resource = resource
-    @repo = RepositoryHandle.new(resource, log)
+    @repo = ContentServerConnection.new(resource, log)
     @log = log # Okay if it's nil.
     @files = []
   end

--- a/app/models/publishing/fast.rb
+++ b/app/models/publishing/fast.rb
@@ -33,7 +33,7 @@ class Publishing::Fast
   def initialize(resource, log = nil)
     @start_at = Time.now
     @resource = resource
-    @repo = Repository.new(resource, log)
+    @repo = RepositoryHandle.new(resource, log)
     @log = log # Okay if it's nil.
     @files = []
   end

--- a/app/models/repository_handle.rb
+++ b/app/models/repository_handle.rb
@@ -1,4 +1,4 @@
-class Repository
+class RepositoryHandle
   def initialize(resource, log = nil)
     @resource = resource
     repo_url = Rails.application.secrets.repository[:url]

--- a/app/models/trait_bank/slurp.rb
+++ b/app/models/trait_bank/slurp.rb
@@ -3,7 +3,7 @@ class TraitBank::Slurp
     delegate :query, to: TraitBank
 
     def load_resource_from_repo(resource)
-      repo = RepositoryHandle.new(resource)
+      repo = ContentServerConnection.new(resource)
       repo.copy_file(resource.traits_file, 'traits.tsv')
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       TraitBank.create_resource(resource.id)
@@ -12,7 +12,7 @@ class TraitBank::Slurp
     end
 
     def load_resource_metadata_from_repo(resource)
-      repo = Repository_Handle.new(resource)
+      repo = ContentServerConnection.new(resource)
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       config = load_csv_config(resource.id, single_resource: true)
       basename = File.basename(resource.meta_traits_file)
@@ -23,7 +23,7 @@ class TraitBank::Slurp
     end
 
     def heal_traits(resource)
-      repo = RepositoryHandle.new(resource)
+      repo = ContentServerConnection.new(resource)
       repo.copy_file(resource.traits_file, 'traits.tsv')
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       heal_traits_by_type("traits_#{resource.id}.csv", :Trait, resource.id)

--- a/app/models/trait_bank/slurp.rb
+++ b/app/models/trait_bank/slurp.rb
@@ -3,7 +3,7 @@ class TraitBank::Slurp
     delegate :query, to: TraitBank
 
     def load_resource_from_repo(resource)
-      repo = Repository.new(resource)
+      repo = RepositoryHandle.new(resource)
       repo.copy_file(resource.traits_file, 'traits.tsv')
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       TraitBank.create_resource(resource.id)
@@ -12,7 +12,7 @@ class TraitBank::Slurp
     end
 
     def load_resource_metadata_from_repo(resource)
-      repo = Repository.new(resource)
+      repo = Repository_Handle.new(resource)
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       config = load_csv_config(resource.id, single_resource: true)
       basename = File.basename(resource.meta_traits_file)
@@ -23,7 +23,7 @@ class TraitBank::Slurp
     end
 
     def heal_traits(resource)
-      repo = Repository.new(resource)
+      repo = RepositoryHandle.new(resource)
       repo.copy_file(resource.traits_file, 'traits.tsv')
       repo.copy_file(resource.meta_traits_file, 'metadata.tsv')
       heal_traits_by_type("traits_#{resource.id}.csv", :Trait, resource.id)


### PR DESCRIPTION
There were two `Repository` classes.  The PR renames one of them to `RepositoryHandle` because when I attempted to run the webapp, ruby was in some cases resolving the name to the wrong class.  Addresses #59 .

I think the morpheme 'handle' is cowardly, since it has almost no meaning, but couldn't think of a better one.
